### PR TITLE
Added the ability to search for units without specific abilities

### DIFF
--- a/src/app/(builder)/builder/filteredTable.tsx
+++ b/src/app/(builder)/builder/filteredTable.tsx
@@ -16,11 +16,18 @@ function includesIfFilter(filter: string | undefined, value: string) {
     return matchesIfFilter(filter, (f) => (value) ? value.toLowerCase().includes(f.toLowerCase()) : false);
 }
 
-function matchAbilities(filter: string, value: string) {
+function matchAbilities(filter: string, abilities: string) {
     const queries = filter.split(new RegExp("[, ]+"));
-    return queries.reduce((res, q) => {
-        return value?.toLowerCase().includes(q.toLowerCase().trim());
-    }, true);
+    const matches = queries.map((query) => {
+        query = query.toLowerCase().trim();
+        const neg = query.startsWith("!");
+        const contains = abilities
+          ?.toLowerCase()
+          .includes(neg ? query.slice(1) : query);
+        return neg ? !contains : contains;
+    }).every((match) => match === true);
+    console.log(matches);
+    return matches;
 }
 
 function matchDmg(filter: string, unit: IUnit) {

--- a/src/app/(builder)/builder/filteredTable.tsx
+++ b/src/app/(builder)/builder/filteredTable.tsx
@@ -18,15 +18,13 @@ function includesIfFilter(filter: string | undefined, value: string) {
 
 function matchAbilities(filter: string, abilities: string) {
     const queries = filter.split(new RegExp("[, ]+"));
-    const matches = queries.map((query) => {
+    const matches = queries.reduce((res, query) => {
         query = query.toLowerCase().trim();
-        const neg = query.startsWith("!");
-        const contains = abilities
-          ?.toLowerCase()
-          .includes(neg ? query.slice(1) : query);
-        return neg ? !contains : contains;
-    }).every((match) => match === true);
-    console.log(matches);
+        const cleanQ = query.replace(/^!/, '');
+        const neg = query != cleanQ;
+        const contains = abilities?.toLowerCase().includes(cleanQ);
+        return res && (neg !== contains);
+    }, true);
     return matches;
 }
 


### PR DESCRIPTION
I've just added the option to put a ! before an ability in the abilities search box to search for units without a specific ability. helpful to just cut out things like C3 and mhq that add points but might not be needed. Something I wanted and I figured others might want too!